### PR TITLE
feat: serve MCP over streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 
 - [Install](#installation) SSH MCP Server
 - [Configure](#configuration) SSH MCP Server
-- [Set up](#client-setup) your MCP Client (e.g. Claude Desktop, Cursor, etc)
+- [Expose the HTTP endpoint](#streamable-http-server) if you want to connect over the network
+- [Set up](#client-setup) your MCP Client (e.g. Claude Desktop, Cursor, GitHub Copilot Studio, etc)
 - Execute remote shell commands on your Linux or Windows server via natural language
 
 ## Features
@@ -61,9 +62,39 @@
    npm install
    ```
 
+## Streamable HTTP Server
+
+Starting with v1.1.0 the server ships with a [Streamable HTTP transport](https://modelcontextprotocol.io/specs/streaming-http) so
+that you can host it behind a public endpoint or reverse proxy and connect from remote MCP clients such as GitHub Copilot Studio
+agents.
+
+```bash
+npx ssh-mcp -- \
+  --host=1.2.3.4 \
+  --user=root \
+  --password=pass \
+  --listen-port=8080 \
+  --listen-host=0.0.0.0 \
+  --base-path=/mcp \
+  --allow-origin="https://your-domain.example" \
+  --enable-json-response
+```
+
+**HTTP Options:**
+
+- `listen-host` *(default: `0.0.0.0`)* — network interface the HTTP server binds to
+- `listen-port` *(default: `3000`)* — TCP port exposed by the server
+- `base-path` *(default: `/mcp`)* — URL path where the MCP endpoint is served
+- `allow-origin` *(default: `*`)* — value returned in `Access-Control-Allow-Origin` headers for CORS/SSE
+- `enable-json-response` — allow non-streaming JSON responses for simple calls (optional but recommended for proxies)
+
+You can place the binary behind an HTTPS reverse proxy (nginx, Caddy, Cloudflare Tunnel, etc.) and expose the chosen `base-path`
+to the internet. Remember to secure the proxy with authentication or IP restrictions—anyone who can reach this endpoint can send
+commands to your SSH target.
+
 ## Client Setup
 
-You can configure Claude Desktop to use this MCP Server.
+You can configure MCP clients such as Claude Desktop or GitHub Copilot Studio to use this server.
 
 **Required Parameters:**
 - `host`: Hostname or IP of the Linux or Windows server

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-mcp",
   "license": "MIT",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "MCP server exposing SSH control for Linux and Windows systems via Model Context Protocol.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { Client as SSHClient } from 'ssh2';
 import { z } from 'zod';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { randomUUID } from 'crypto';
 
 // Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000
 function parseArgv() {
@@ -26,12 +28,38 @@ const USER = argvConfig.user;
 const PASSWORD = argvConfig.password;
 const KEY = argvConfig.key;
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
+const LISTEN_HOST = argvConfig["listen-host"] ?? '0.0.0.0';
+const LISTEN_PORT = argvConfig["listen-port"] ? parseInt(argvConfig["listen-port"]) : 3000;
+const RAW_BASE_PATH = argvConfig["base-path"] ?? '/mcp';
+const ENABLE_JSON_RESPONSE = parseBoolean(argvConfig["enable-json-response"]);
+const ALLOW_ORIGIN = argvConfig["allow-origin"] ?? '*';
+
+function parseBoolean(value?: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+function normalizeBasePath(path: string): string {
+  if (!path.startsWith('/')) {
+    path = '/' + path;
+  }
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.replace(/\/+$/, '');
+  }
+  return path;
+}
+
+const BASE_PATH = normalizeBasePath(RAW_BASE_PATH);
 
 function validateConfig(config: Record<string, string>) {
   const errors = [];
   if (!config.host) errors.push('Missing required --host');
   if (!config.user) errors.push('Missing required --user');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
+  if (config["listen-port"] && isNaN(Number(config["listen-port"]))) errors.push('Invalid --listen-port');
+  if (BASE_PATH.length === 0) errors.push('Invalid --base-path');
   if (errors.length > 0) {
     throw new Error('Configuration error:\n' + errors.join('\n'));
   }
@@ -42,7 +70,7 @@ validateConfig(argvConfig);
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '1.0.7',
+  version: '1.1.0',
   capabilities: {
     resources: {},
     tools: {},
@@ -164,12 +192,83 @@ async function execSshCommand(sshConfig: any, command: string): Promise<{ [x: st
 }
 
 async function main() {
-  const transport = new StdioServerTransport();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    enableJsonResponse: ENABLE_JSON_RESPONSE,
+  });
+
   await server.connect(transport);
-  console.error("SSH MCP Server running on stdio");
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      await handleHttpRequest(transport, req, res);
+    } catch (error) {
+      console.error('Fatal error while handling request:', error);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal Server Error' }));
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(LISTEN_PORT, LISTEN_HOST, () => {
+      console.error(
+        `SSH MCP Server listening on http://${LISTEN_HOST}:${LISTEN_PORT}${BASE_PATH}`
+      );
+      resolve();
+    });
+  });
 }
 
 main().catch((error) => {
   console.error("Fatal error in main():", error);
   process.exit(1);
 });
+
+async function handleHttpRequest(
+  transport: StreamableHTTPServerTransport,
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  if (!req.url) {
+    writeCorsHeaders(res);
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Missing request URL' }));
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+
+  if (!url.pathname.startsWith(BASE_PATH)) {
+    if (req.method === 'OPTIONS') {
+      writeCorsHeaders(res);
+      res.writeHead(204).end();
+      return;
+    }
+
+    writeCorsHeaders(res);
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+    return;
+  }
+
+  if (req.method === 'OPTIONS') {
+    writeCorsHeaders(res);
+    res.writeHead(204).end();
+    return;
+  }
+
+  writeCorsHeaders(res);
+
+  await transport.handleRequest(req, res);
+}
+
+function writeCorsHeaders(res: ServerResponse) {
+  res.setHeader('Access-Control-Allow-Origin', ALLOW_ORIGIN);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization');
+  res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+}


### PR DESCRIPTION
## Summary
- replace the stdio transport with the MCP Streamable HTTP transport and host the server via Node's HTTP module
- add configurable HTTP options (listen host/port, base path, CORS origin, JSON responses) while preserving SSH execution logic
- document the new Streamable HTTP deployment workflow and bump the package version to 1.1.0

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4ae7b55f8832c9ca3b20d8ff3431a